### PR TITLE
:gear: Libssh2 1.10.0 with tipi and platform / hunter dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ tags
 libssh2.pc
 TAGS
 *~
+.DS_Store
+build/

--- a/.tipi/opts
+++ b/.tipi/opts
@@ -1,0 +1,8 @@
+set(CRYPTO_BACKEND "OpenSSL" CACHE STRING "crypto backend" FORCE)
+set(ENABLE_ZLIB_COMPRESSION ON CACHE BOOL "Enable zlib compression" FORCE)
+
+# Examples
+set(BUILD_EXAMPLES OFF CACHE BOOL "no example" FORCE)
+
+# Tests
+set(BUILD_TESTING OFF CACHE BOOL "no test" FORCE)

--- a/.tipi/opts.vs-16-2019-win64-cxx17
+++ b/.tipi/opts.vs-16-2019-win64-cxx17
@@ -1,0 +1,10 @@
+add_compile_definitions(
+    NOMINMAX
+    WIN32_LEAN_AND_MEAN
+    _WIN32_WINNT=0x0A00 # We have to set the windows version targeted
+    WINVER=0x0A00 # We have to set the windows version targeted
+)
+
+add_compile_options(
+    /bigobj
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,17 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 # OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.17.0)
+##### PLATFORM deps ##### 
+set(HUNTER_ROOT $ENV{HUNTER_ROOT})
+include(HunterGate)
+HunterGate(
+    URL "unused"
+    SHA1 "unused"
+)
+##### PLATFORM deps #####
 
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 project(libssh2 C)
 set(PROJECT_URL "https://www.libssh2.org/")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,10 @@ include(CheckNonblockingSocketSupport)
 include(SocketLibraries)
 
 ## Cryptography backend choice
+hunter_add_package(OpenSSL COMPONENTS )
+hunter_add_package(ZLIB COMPONENTS)
+
+
 
 set(CRYPTO_BACKEND
   ""
@@ -211,7 +215,7 @@ set(SOURCES
   userauth.h
   version.c)
 
-if(WIN32)
+if(WIN32 AND BUILD_SHARED_LIBS)
   list(APPEND SOURCES ${PROJECT_SOURCE_DIR}/win32/libssh2.rc)
 endif()
 


### PR DESCRIPTION
This is the first version of libssh2 used in tipi that is using hunter to still build it's deps.